### PR TITLE
fix: don't let scheduled tasks reset Workshop idle timer

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -374,8 +374,10 @@ func main() {
 					continue
 				}
 
-				// Real task arrived — preempt any creative work
-				if workshop != nil {
+				// Real task arrived — preempt any creative work.
+				// Scheduled tasks (status-page, etc.) are automated housekeeping
+				// and shouldn't reset the Workshop idle timer.
+				if workshop != nil && scheduler.ParentTaskID(task.ID) == "" {
 					workshop.OnTaskDispatched(ctx)
 				}
 


### PR DESCRIPTION
## Summary

- Scheduled tasks (like `status-page` running every 6h) were going through `workshop.OnTaskDispatched()`, resetting the idle timer on every run
- With `creative_idle_threshold: 6h` matching the 6h schedule, the Workshop could never accumulate enough idle time to trigger — the timer reset right at the threshold boundary every time
- Fix: skip `OnTaskDispatched` for tasks spawned by the scheduler (detected via `scheduler.ParentTaskID`)

Previously this was masked because the idle threshold was 4h, which fit between the 6h scheduled runs. After bumping to 6h they perfectly cancelled out.

## Test plan

- [x] `go build` succeeds
- [x] All 12 test suites pass
- [ ] After deploy, verify Workshop triggers within `creative_idle_threshold` of the last real (non-scheduled) task

🤖 Generated with [Claude Code](https://claude.com/claude-code)