### PR TITLE
Phase 0: stop the bleed — gate goal-less free-time behind free_creative_enabled (default off)

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -16,6 +16,10 @@ scheduler:
   job_ttl_after_finished: 1h
   creative_mode_enabled: true
   creative_idle_threshold: 4h
+  # Goal-less "free time" sessions are off by default — when there is no
+  # approved/scoped work, the Workshop idles instead of free-associating.
+  # Earned creative time (spent credits) and maintenance are unaffected.
+  free_creative_enabled: false
 
 worker:
   image: ghcr.io/dacort/claude-os-worker:latest

--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -57,6 +57,14 @@ type SchedulerConfig struct {
 	CreativeModeEnabled   bool   `yaml:"creative_mode_enabled"`
 	CreativeIdleThreshold string `yaml:"creative_idle_threshold"`
 
+	// FreeCreativeEnabled controls goal-less "free time" sessions. When false
+	// (the default), the Workshop idles instead of dispatching a free-form
+	// creative session when there is no approved/scoped work waiting. Earned
+	// creative time (a spent credit) and maintenance sessions are unaffected.
+	// This is the Phase 0 "stop the bleed" gate: open-ended free time is what
+	// produced the self-referential essay corpus.
+	FreeCreativeEnabled bool `yaml:"free_creative_enabled"`
+
 	// Project-aware Workshop (v2): scan this directory for project.md files.
 	// Leave empty to disable project work selection.
 	ProjectsDir string `yaml:"projects_dir"`

--- a/controller/config/config_test.go
+++ b/controller/config/config_test.go
@@ -40,6 +40,7 @@ scheduler:
   job_ttl_after_finished: 30m
   creative_mode_enabled: false
   creative_idle_threshold: 5m
+  free_creative_enabled: true
 worker:
   image: test:latest
   namespace: test-ns
@@ -71,5 +72,17 @@ worker:
 	}
 	if cfg.Scheduler.TTLDuration() != 30*time.Minute {
 		t.Errorf("expected 30m TTL, got %v", cfg.Scheduler.TTLDuration())
+	}
+	if !cfg.Scheduler.FreeCreativeEnabled {
+		t.Error("expected free_creative_enabled to parse as true")
+	}
+}
+
+// TestFreeCreativeEnabled_DefaultsFalse verifies that the Phase 0 stop-the-bleed
+// gate is off unless explicitly enabled — a config that omits the field (or a
+// zero-value struct) must not grant goal-less free time.
+func TestFreeCreativeEnabled_DefaultsFalse(t *testing.T) {
+	if (SchedulerConfig{}).FreeCreativeEnabled {
+		t.Error("FreeCreativeEnabled should default to false")
 	}
 }

--- a/controller/creative/creative.go
+++ b/controller/creative/creative.go
@@ -52,6 +52,11 @@ type Workshop struct {
 	creditLedger  *ledger.Ledger
 	backlogClient *backlog.Client
 	activeType    SessionType // session type of the currently active job
+
+	// freeCreativeEnabled gates goal-less free-time sessions. Default false
+	// (Phase 0 stop-the-bleed): when there is no approved/scoped work, idle
+	// instead of dispatching a free-form creative essay session.
+	freeCreativeEnabled bool
 }
 
 func NewWorkshop(
@@ -86,6 +91,14 @@ func NewWorkshop(
 func (w *Workshop) EnableMaintenance(l *ledger.Ledger, b *backlog.Client) {
 	w.creditLedger = l
 	w.backlogClient = b
+}
+
+// EnableFreeCreative toggles goal-less "free time" sessions. When false (the
+// default), the Workshop idles instead of running a free-form creative session
+// when there is no approved/scoped work. Earned creative time (a spent credit)
+// and maintenance are unaffected.
+func (w *Workshop) EnableFreeCreative(enabled bool) {
+	w.freeCreativeEnabled = enabled
 }
 
 // OnTaskDispatched resets the idle timer and preempts any creative job.
@@ -177,6 +190,12 @@ func (w *Workshop) startCreativeTask(ctx context.Context) {
 // startSession picks the session type per the decision table and dispatches.
 func (w *Workshop) startSession(ctx context.Context) {
 	if w.creditLedger == nil || w.backlogClient == nil {
+		// Pure v2 path (no maintenance wiring): there is no approved backlog to
+		// consult, so the only option is free creative — gated by the flag.
+		if !w.freeCreativeEnabled {
+			w.idle("no maintenance wiring and free creative disabled")
+			return
+		}
 		w.activeType = SessionCreativeFree
 		w.startCreativeTask(ctx)
 		return
@@ -190,7 +209,7 @@ func (w *Workshop) startSession(ctx context.Context) {
 		issues = nil
 	}
 
-	switch DecideSession(len(issues), w.creditLedger.Balance()) {
+	switch DecideSession(len(issues), w.creditLedger.Balance(), w.freeCreativeEnabled) {
 	case SessionMaintenance:
 		w.activeType = SessionMaintenance
 		w.startMaintenanceTask(ctx, issues[0])
@@ -203,7 +222,17 @@ func (w *Workshop) startSession(ctx context.Context) {
 	case SessionCreativeFree:
 		w.activeType = SessionCreativeFree
 		w.startCreativeTask(ctx)
+	case SessionIdle:
+		w.idle("no approved work and free creative disabled")
 	}
+}
+
+// idle records that the Workshop deliberately dispatched nothing this cycle and
+// resets the idle timer so CheckIdle backs off for another threshold period
+// rather than re-deciding (and re-hitting the backlog API) every tick.
+func (w *Workshop) idle(reason string) {
+	slog.Info("workshop: idling, no session dispatched", "reason", reason)
+	w.lastTask = time.Now()
 }
 
 // startMaintenanceTask dispatches a maintenance session for the given issue.

--- a/controller/creative/creative_test.go
+++ b/controller/creative/creative_test.go
@@ -239,6 +239,26 @@ func TestSelectProjectWork_WeightZero(t *testing.T) {
 	}
 }
 
+// TestStartSession_IdleWhenFreeCreativeDisabled verifies the Phase 0 gate: with
+// no maintenance wiring (creditLedger/backlogClient nil) and free creative
+// disabled (the default), startSession dispatches nothing and resets the idle
+// timer — without touching the nil dispatcher.
+func TestStartSession_IdleWhenFreeCreativeDisabled(t *testing.T) {
+	w := &Workshop{} // freeCreativeEnabled defaults to false
+
+	w.startSession(context.Background())
+
+	if w.active {
+		t.Error("expected no active session when idling")
+	}
+	if w.activeJob != "" {
+		t.Errorf("expected no active job, got %q", w.activeJob)
+	}
+	if w.lastTask.IsZero() {
+		t.Error("expected idle to reset lastTask, but it is still zero")
+	}
+}
+
 // TestProjectLockHelpers verifies the Redis lock round-trip.
 func TestProjectLockHelpers(t *testing.T) {
 	rdb := newTestRedis(t)

--- a/controller/creative/decide.go
+++ b/controller/creative/decide.go
@@ -11,14 +11,25 @@ const (
 	// SessionCreativeFree is a creative session granted because there is no
 	// approved work waiting — the gate only exists when real work is pending.
 	SessionCreativeFree
+	// SessionIdle dispatches nothing: there is no approved/scoped work and
+	// goal-less free time is disabled. The Workshop simply waits.
+	SessionIdle
 )
 
 // DecideSession implements the chores-before-dessert decision table
 // (spec 2026-06-10, section 1). approvedBacklog is the count of open
 // octo-approved issues; credits is the current ledger balance.
-func DecideSession(approvedBacklog, credits int) SessionType {
+//
+// freeCreativeEnabled gates goal-less "free time" (Phase 0 stop-the-bleed):
+// when false and there is no approved work, the result is SessionIdle rather
+// than SessionCreativeFree. Earned creative time (SessionCreativeSpend) and
+// maintenance (SessionMaintenance) are unaffected by the flag.
+func DecideSession(approvedBacklog, credits int, freeCreativeEnabled bool) SessionType {
 	if approvedBacklog == 0 {
-		return SessionCreativeFree
+		if freeCreativeEnabled {
+			return SessionCreativeFree
+		}
+		return SessionIdle
 	}
 	if credits >= 1 {
 		return SessionCreativeSpend

--- a/controller/creative/decide_test.go
+++ b/controller/creative/decide_test.go
@@ -4,21 +4,28 @@ import "testing"
 
 func TestDecideSession(t *testing.T) {
 	tests := []struct {
-		name    string
-		backlog int
-		credits int
-		want    SessionType
+		name        string
+		backlog     int
+		credits     int
+		freeEnabled bool
+		want        SessionType
 	}{
-		{"work waiting, no credits -> maintenance", 3, 0, SessionMaintenance},
-		{"work waiting, has credit -> spend on creative", 3, 1, SessionCreativeSpend},
-		{"work waiting, max credits -> spend on creative", 1, 3, SessionCreativeSpend},
-		{"empty backlog, no credits -> free creative", 0, 0, SessionCreativeFree},
-		{"empty backlog, has credits -> free creative (no spend)", 0, 2, SessionCreativeFree},
+		// Approved work waiting — the free-creative flag is irrelevant here.
+		{"work waiting, no credits -> maintenance", 3, 0, false, SessionMaintenance},
+		{"work waiting, has credit -> spend on creative", 3, 1, false, SessionCreativeSpend},
+		{"work waiting, max credits -> spend on creative", 1, 3, false, SessionCreativeSpend},
+		{"work waiting, free enabled, has credit -> still spend", 3, 1, true, SessionCreativeSpend},
+		// Empty backlog — gated by the free-creative flag.
+		{"empty backlog, free disabled -> idle", 0, 0, false, SessionIdle},
+		{"empty backlog, free disabled, has credits -> idle", 0, 2, false, SessionIdle},
+		{"empty backlog, free enabled -> free creative", 0, 0, true, SessionCreativeFree},
+		{"empty backlog, free enabled, has credits -> free creative (no spend)", 0, 2, true, SessionCreativeFree},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DecideSession(tt.backlog, tt.credits); got != tt.want {
-				t.Errorf("DecideSession(%d, %d) = %v, want %v", tt.backlog, tt.credits, got, tt.want)
+			if got := DecideSession(tt.backlog, tt.credits, tt.freeEnabled); got != tt.want {
+				t.Errorf("DecideSession(%d, %d, %v) = %v, want %v",
+					tt.backlog, tt.credits, tt.freeEnabled, got, tt.want)
 			}
 		})
 	}

--- a/controller/main.go
+++ b/controller/main.go
@@ -177,11 +177,13 @@ func main() {
 			cfg.Scheduler.ProjectWeight(),
 			rdb,
 		)
+		workshop.EnableFreeCreative(cfg.Scheduler.FreeCreativeEnabled)
 		slog.Info("workshop enabled",
 			"idle_threshold", cfg.Scheduler.IdleThreshold(),
 			"usage_check", oauthToken != "",
 			"projects_dir", cfg.Scheduler.ProjectsDir,
 			"project_weight", cfg.Scheduler.ProjectWeight,
+			"free_creative_enabled", cfg.Scheduler.FreeCreativeEnabled,
 		)
 	}
 


### PR DESCRIPTION
## What & why

Open-ended Workshop "free time" with no goal is what produced the self-referential essay corpus (`knowledge/field-notes/`, `handoffs/`, `parables/`, the `on-*.md` cluster — ~706 files / ~597k words). Given nothing scoped to do, the worker falls back to producing text about itself. In the last 60 commits before this branch, 46 were workshop/essay and only 4 were feat/fix.

This is **Phase 0 ("stop the bleed")** of the Forge scoping-loop direction: replace goal-less creative time with idle, so the system stops narrating itself while idle.

## Change

Adds a `free_creative_enabled` flag (**default `false`**). When there is no approved/scoped work and the flag is off, `DecideSession` returns a new `SessionIdle` outcome and the Workshop dispatches nothing (resetting its timer to back off rather than re-deciding every tick).

**Unaffected:** earned creative time (a spent credit → `SessionCreativeSpend`) and maintenance sessions. You can still earn dessert by doing real work.

- `config/controller.yaml`: `free_creative_enabled: false`
- `controller/config`: new `SchedulerConfig.FreeCreativeEnabled` (+ tests for parse & false-default)
- `controller/creative`: `SessionIdle` outcome, `idle()` helper, flag wired through `DecideSession` and `startSession` (+ tests)
- `controller/main.go`: `workshop.EnableFreeCreative(cfg.Scheduler.FreeCreativeEnabled)`

## Not in this PR

Archiving the existing ~600k-word corpus (a destructive `git mv`) is **intentionally excluded** — handled separately with its own sign-off.

## Verification

`go build ./...` and `go test ./...` green in the `controller/` module locally (all 14 packages pass).

Authored in cloud session https://claude.ai/code/session_013hJXxw9mz3rQ4uMGaxTzSE (which couldn't push from its sandbox); applied, tested, and opened from the brain session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)