### PR TITLE
fix(codex): pin an explicit model for codex exec (default gpt-5.5)

### DIFF
--- a/controller/dispatcher/dispatcher.go
+++ b/controller/dispatcher/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 
@@ -51,6 +52,20 @@ func sanitizeName(id string) string {
 
 // agentSecrets returns the EnvFrom sources, extra env vars, extra volume mounts,
 // and extra volumes needed for a given agent type.
+// defaultCodexModel is the model passed to `codex exec` when the controller
+// has no CODEX_MODEL override. The codex CLI's built-in default drifts with
+// migrations (gpt-5-codex → gpt-5.3-codex → gpt-5.4 → …) and lands on models
+// the ChatGPT subscription doesn't expose, so we pin an explicit, supported one.
+// Override without an image rebuild by setting CODEX_MODEL on the controller.
+const defaultCodexModel = "gpt-5.5"
+
+func codexModel() string {
+	if m := os.Getenv("CODEX_MODEL"); m != "" {
+		return m
+	}
+	return defaultCodexModel
+}
+
 func agentSecrets(agent string) ([]corev1.EnvFromSource, []corev1.EnvVar, []corev1.VolumeMount, []corev1.Volume) {
 	switch agent {
 	case "codex":
@@ -61,6 +76,7 @@ func agentSecrets(agent string) ([]corev1.EnvFromSource, []corev1.EnvVar, []core
 			},
 			[]corev1.EnvVar{
 				{Name: "CODEX_HOME", Value: "/home/worker/.codex"},
+				{Name: "CODEX_MODEL", Value: codexModel()},
 			},
 			[]corev1.VolumeMount{
 				{Name: "codex-auth", MountPath: "/tmp/codex-auth", ReadOnly: true},

--- a/controller/dispatcher/dispatcher_test.go
+++ b/controller/dispatcher/dispatcher_test.go
@@ -211,8 +211,25 @@ func TestCreateJobWithAgent(t *testing.T) {
 				if envMap["CODEX_HOME"] != "/home/worker/.codex" {
 					t.Errorf("CODEX_HOME = %q, want /home/worker/.codex", envMap["CODEX_HOME"])
 				}
+
+				// codex jobs must pin an explicit model; the CLI default drifts
+				// to models the ChatGPT subscription rejects.
+				if envMap["CODEX_MODEL"] == "" {
+					t.Error("expected CODEX_MODEL to be set on codex jobs")
+				}
 			}
 		})
+	}
+}
+
+func TestCodexModel(t *testing.T) {
+	t.Setenv("CODEX_MODEL", "")
+	if got := codexModel(); got != defaultCodexModel {
+		t.Errorf("codexModel() with no override = %q, want %q", got, defaultCodexModel)
+	}
+	t.Setenv("CODEX_MODEL", "gpt-5.4")
+	if got := codexModel(); got != "gpt-5.4" {
+		t.Errorf("codexModel() with override = %q, want gpt-5.4", got)
 	}
 }
 

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -640,7 +640,11 @@ case "$AGENT" in
     ;;
   codex)
     CODEX_PROMPT=$(build_codex_instruction_block)
+    # Pin an explicit model: the codex CLI default drifts across migrations to
+    # models the ChatGPT subscription rejects (400 "model is not supported").
+    # CODEX_MODEL is injected by the controller (default gpt-5.5).
     codex exec \
+        --model "${CODEX_MODEL:-gpt-5.5}" \
         --dangerously-bypass-approvals-and-sandbox \
         --skip-git-repo-check \
         "${CODEX_PROMPT}" \


### PR DESCRIPTION
## The bug

Every Codex worker was dying immediately with:

```
400 invalid_request_error: The 'gpt-5.3-codex' model is not supported
when using Codex with a ChatGPT account.
```

`worker/entrypoint.sh` invoked `codex exec` with **no `--model` flag**, so it inherited the codex CLI's built-in default. That default drifts across migrations (`gpt-5-codex → gpt-5.3-codex → gpt-5.4 → …`, visible in the local `~/.codex/config.toml` migration notice) and lands on models the ChatGPT subscription doesn't expose.

Combined with a separately-expired auth token (refreshed out-of-band), **the Codex agent had been silently dead** — nothing in the system noticed until a review task tried to use it.

## Fix

Pin an explicit, supported model, configurable without an image rebuild:

- `controller/dispatcher`: inject `CODEX_MODEL` on codex jobs (mirrors `ANTHROPIC_MODEL`), defaulting to `gpt-5.5`, overridable via the controller's `CODEX_MODEL` env — so the next migration is a one-line GitOps change in talos-homelab, not a code change.
- `worker/entrypoint.sh`: `codex exec --model "${CODEX_MODEL:-gpt-5.5}" …`
- tests: assert `CODEX_MODEL` is set on codex jobs + `codexModel()` env override.

## Verification

`go build ./...`, `go vet ./dispatcher/...`, `go test ./...` all green (controller module); `bash -n worker/entrypoint.sh` clean.

## Follow-up (not in this PR)

The real gap is that **nothing health-checks the agents**. A periodic per-agent smoke test (ask each agent to echo "ok", file an issue on failure) would have caught *both* this model bug and the expired token days before a human hit them. Worth its own capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)