### PR TITLE
fix(worker): bump codex CLI 0.120.0 → 0.142.0 to support gpt-5.5

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install CLI tools (Claude Code, Codex, Gemini)
-RUN npm install -g @anthropic-ai/claude-code @openai/codex@0.120.0 @google/gemini-cli
+RUN npm install -g @anthropic-ai/claude-code @openai/codex@0.142.0 @google/gemini-cli
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Why

PR #22 pinned `CODEX_MODEL=gpt-5.5` for codex workers. That pin is correct — gpt-5.5 is the default model on a current ChatGPT/Codex account (verified against the locally-installed codex 0.142.0). But the **worker image still shipped `@openai/codex@0.120.0`**, 22 minor versions behind, which rejects gpt-5.5:

```
400 invalid_request_error: The 'gpt-5.5' model requires a newer version of Codex.
```

So the codex agent was *still* dead after #22 — just with a different error (auth + exec now work; only the CLI version blocks it).

## Change

Bump the worker's codex CLI `0.120.0 → 0.142.0` (matches the version in active local use). With a current CLI, the pinned gpt-5.5 resolves and codex review tasks can run.

## Validation

- Confirmed locally: codex 0.142.0 lists gpt-5.5 in its model cache and uses it as the default.
- After merge + auto-deploy, re-dispatch `codex-review-ghostband-hub-flip-3` to confirm a clean run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)