### PR TITLE
feat(health): daily per-agent health canaries + failure→issue bridge

### DIFF
--- a/controller/health/health.go
+++ b/controller/health/health.go
@@ -1,0 +1,138 @@
+// Package health turns agent-health canary task results into deduplicated
+// GitHub issues.
+//
+// Canary tasks (tasks/scheduled/agent-health-<agent>.md) exercise each agent
+// backend through the real dispatch path on a daily cron. When one fails, the
+// controller opens (or updates) a single issue per agent; when the next run
+// succeeds, the issue is closed. Open-on-fail / dedup / close-on-recover all
+// fall out of the existing comms.Manager (Notify dedups by TaskID,
+// Close is idempotent), so this package is just the glue.
+package health
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dacort/claude-os/controller/comms"
+)
+
+// Prefix marks a task as an agent-health canary. Task IDs look like
+// "agent-health-codex", "agent-health-claude", "agent-health-gemini".
+const Prefix = "agent-health-"
+
+// Notifier is the subset of comms.Manager this package needs.
+type Notifier interface {
+	Notify(ctx context.Context, msg comms.Message) error
+	Close(ctx context.Context, id string) error
+}
+
+// IsCanary reports whether taskID belongs to an agent-health canary.
+func IsCanary(taskID string) bool {
+	return strings.HasPrefix(taskID, Prefix) && len(taskID) > len(Prefix)
+}
+
+// Agent extracts the agent name from a canary task ID
+// ("agent-health-codex" -> "codex"). Returns "" if taskID is not a canary.
+func Agent(taskID string) string {
+	if !IsCanary(taskID) {
+		return ""
+	}
+	return strings.TrimPrefix(taskID, Prefix)
+}
+
+// HandleTerminal reacts to a finished canary task. On failure it opens/updates
+// the agent's health issue; on success it closes any open one. It is a no-op
+// for non-canary task IDs, so callers can hand it every terminal task.
+func HandleTerminal(ctx context.Context, n Notifier, taskID string, succeeded bool, logs string) error {
+	if !IsCanary(taskID) {
+		return nil
+	}
+	agent := Agent(taskID)
+
+	if succeeded {
+		// Quiet on success — close the issue if one is open, idempotent otherwise.
+		return n.Close(ctx, taskID)
+	}
+
+	return n.Notify(ctx, comms.Message{
+		ID:      taskID,
+		TaskID:  taskID,
+		Type:    comms.NeedsHuman, // yields the needs-human label that dedup/close key on
+		Project: "agent-health",
+		Title:   fmt.Sprintf("Agent unhealthy: %s", agent),
+		Body:    buildBody(agent, logs),
+	})
+}
+
+// buildBody renders the issue body: what failed, the most relevant error line,
+// a short log tail, and pointers to the remediation runbooks.
+func buildBody(agent, logs string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "The daily `%s` health canary failed, which means a real task routed to "+
+		"`%s` would likely fail too.\n\n", agent, agent)
+
+	if line := firstErrorLine(logs); line != "" {
+		fmt.Fprintf(&b, "**Likely cause:** `%s`\n\n", line)
+	}
+
+	fmt.Fprintf(&b, "<details><summary>Log tail</summary>\n\n```\n%s\n```\n</details>\n\n", logTail(logs, 25))
+
+	b.WriteString("**Remediation pointers**\n")
+	switch agent {
+	case "codex":
+		b.WriteString("- Expired token → re-run `codex login`, recreate the `claude-os-codex` secret.\n")
+		b.WriteString("- `400 not supported` / `requires a newer version` → the pinned `CODEX_MODEL` " +
+			"and the worker's codex CLI version are coupled; bump them together (see claude-os#22, #23).\n")
+	case "claude":
+		b.WriteString("- Auth failure → the `CLAUDE_CODE_OAUTH_TOKEN` in `claude-os-oauth` may have expired; " +
+			"regenerate with `claude setup-token`.\n")
+	case "gemini":
+		b.WriteString("- Gemini is not configured by default (no API key). This issue is expected until " +
+			"a `gemini` secret is added; close it if gemini is intentionally disabled.\n")
+	default:
+		b.WriteString("- Check the agent's auth secret and pinned model.\n")
+	}
+
+	b.WriteString("\n_Filed automatically by the agent health check. This issue dedups by task ID and " +
+		"closes itself when the next canary run succeeds._")
+	return b.String()
+}
+
+// firstErrorLine returns the first line that looks like an error signal, for a
+// one-line "likely cause" summary.
+func firstErrorLine(logs string) string {
+	for _, raw := range strings.Split(logs, "\n") {
+		line := strings.TrimSpace(raw)
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(line, "ERROR") || strings.Contains(lower, "error\"") ||
+			strings.Contains(lower, "invalid_request") || strings.Contains(lower, "not supported") ||
+			strings.Contains(lower, "requires a newer version") {
+			return truncate(line, 200)
+		}
+	}
+	return ""
+}
+
+// logTail returns the last n non-empty lines of logs.
+func logTail(logs string, n int) string {
+	lines := strings.Split(strings.TrimRight(logs, "\n"), "\n")
+	out := make([]string, 0, n)
+	for i := len(lines) - 1; i >= 0 && len(out) < n; i-- {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		out = append([]string{lines[i]}, out...)
+	}
+	if len(out) == 0 {
+		return "(no logs available)"
+	}
+	return strings.Join(out, "\n")
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/controller/health/health_test.go
+++ b/controller/health/health_test.go
@@ -1,0 +1,113 @@
+package health
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dacort/claude-os/controller/comms"
+)
+
+// fakeNotifier records Notify/Close calls.
+type fakeNotifier struct {
+	notified []comms.Message
+	closed   []string
+}
+
+func (f *fakeNotifier) Notify(_ context.Context, msg comms.Message) error {
+	f.notified = append(f.notified, msg)
+	return nil
+}
+
+func (f *fakeNotifier) Close(_ context.Context, id string) error {
+	f.closed = append(f.closed, id)
+	return nil
+}
+
+func TestIsCanary(t *testing.T) {
+	cases := map[string]bool{
+		"agent-health-codex":  true,
+		"agent-health-claude": true,
+		"agent-health-":       false, // empty agent
+		"agent-health":        false,
+		"codex-review-foo":    false,
+		"":                    false,
+	}
+	for id, want := range cases {
+		if got := IsCanary(id); got != want {
+			t.Errorf("IsCanary(%q) = %v, want %v", id, got, want)
+		}
+	}
+}
+
+func TestAgent(t *testing.T) {
+	if got := Agent("agent-health-codex"); got != "codex" {
+		t.Errorf("Agent() = %q, want codex", got)
+	}
+	if got := Agent("not-a-canary"); got != "" {
+		t.Errorf("Agent(non-canary) = %q, want empty", got)
+	}
+}
+
+func TestHandleTerminal_FailureOpensIssue(t *testing.T) {
+	n := &fakeNotifier{}
+	logs := "ERROR: {\"type\":\"error\",\"message\":\"The 'gpt-5.5' model requires a newer version of Codex.\"}\nExit code: 1"
+
+	if err := HandleTerminal(context.Background(), n, "agent-health-codex", false, logs); err != nil {
+		t.Fatalf("HandleTerminal returned error: %v", err)
+	}
+
+	if len(n.notified) != 1 {
+		t.Fatalf("expected 1 Notify, got %d", len(n.notified))
+	}
+	msg := n.notified[0]
+	if msg.TaskID != "agent-health-codex" {
+		t.Errorf("TaskID = %q, want agent-health-codex", msg.TaskID)
+	}
+	if msg.Type != comms.NeedsHuman {
+		t.Errorf("Type = %q, want needs-human (dedup/close key on it)", msg.Type)
+	}
+	if msg.Project != "agent-health" {
+		t.Errorf("Project = %q, want agent-health", msg.Project)
+	}
+	if !strings.Contains(msg.Title, "codex") {
+		t.Errorf("Title %q should name the agent", msg.Title)
+	}
+	if !strings.Contains(msg.Body, "requires a newer version") {
+		t.Errorf("Body should surface the error line, got: %s", msg.Body)
+	}
+	if len(n.closed) != 0 {
+		t.Errorf("failure should not Close, got %v", n.closed)
+	}
+}
+
+func TestHandleTerminal_SuccessClosesIssue(t *testing.T) {
+	n := &fakeNotifier{}
+	if err := HandleTerminal(context.Background(), n, "agent-health-claude", true, "OK"); err != nil {
+		t.Fatalf("HandleTerminal returned error: %v", err)
+	}
+	if len(n.closed) != 1 || n.closed[0] != "agent-health-claude" {
+		t.Errorf("expected Close(agent-health-claude), got %v", n.closed)
+	}
+	if len(n.notified) != 0 {
+		t.Errorf("success should not Notify, got %d", len(n.notified))
+	}
+}
+
+func TestHandleTerminal_IgnoresNonCanary(t *testing.T) {
+	n := &fakeNotifier{}
+	// A normal task failing must not touch the health-issue machinery.
+	if err := HandleTerminal(context.Background(), n, "codex-review-ghostband", false, "boom"); err != nil {
+		t.Fatalf("HandleTerminal returned error: %v", err)
+	}
+	if len(n.notified) != 0 || len(n.closed) != 0 {
+		t.Errorf("non-canary task should be a no-op, got notify=%d close=%d", len(n.notified), len(n.closed))
+	}
+}
+
+func TestBuildBody_GeminiNotConfigured(t *testing.T) {
+	body := buildBody("gemini", "no API key configured")
+	if !strings.Contains(body, "not configured") {
+		t.Errorf("gemini body should explain it is expected when unconfigured, got: %s", body)
+	}
+}

--- a/controller/main.go
+++ b/controller/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dacort/claude-os/controller/dispatcher"
 	"github.com/dacort/claude-os/controller/gitsync"
 	"github.com/dacort/claude-os/controller/governance"
+	"github.com/dacort/claude-os/controller/health"
 	"github.com/dacort/claude-os/controller/ledger"
 	"github.com/dacort/claude-os/controller/queue"
 	"github.com/dacort/claude-os/controller/scheduler"
@@ -495,6 +496,12 @@ func main() {
 
 		// Notify scheduler so the next run of a recurring task can proceed
 		taskScheduler.OnTaskCompleted(ctx, taskID)
+
+		// Agent-health canaries: open a deduplicated issue on failure, close it
+		// on recovery. No-op for every other task.
+		if err := health.HandleTerminal(ctx, commsManager, taskID, succeeded, logs); err != nil {
+			slog.Warn("agent-health: failed to update issue", "task", taskID, "error", err)
+		}
 
 		// Log and persist result data.
 		if parsedResult != nil {

--- a/tasks/scheduled/agent-health-claude.md
+++ b/tasks/scheduled/agent-health-claude.md
@@ -1,0 +1,27 @@
+---
+profile: small
+agent: claude
+model: claude-haiku-4-5
+priority: normal
+status: scheduled
+schedule: "30 13 * * *"
+max_concurrent: 1
+created: "2026-06-28T00:00:00Z"
+---
+
+# Agent health canary — claude
+
+## Description
+
+This is an automated health check for the `claude` agent backend. It runs daily
+and exercises the real dispatch path (this worker image, this agent's auth secret,
+this agent's pinned model, and the structured-result contract) so that a broken
+backend is caught here instead of when a real task is routed to it.
+
+Do exactly this and nothing more:
+
+1. Reply with the single word: OK
+2. Emit your structured result block with `outcome` "success".
+
+Do NOT clone any repository, read files, change files, or push anything. There is
+no work to do beyond confirming you can run and emit a valid result.

--- a/tasks/scheduled/agent-health-codex.md
+++ b/tasks/scheduled/agent-health-codex.md
@@ -1,0 +1,26 @@
+---
+profile: small
+agent: codex
+priority: normal
+status: scheduled
+schedule: "35 13 * * *"
+max_concurrent: 1
+created: "2026-06-28T00:00:00Z"
+---
+
+# Agent health canary — codex
+
+## Description
+
+This is an automated health check for the `codex` agent backend. It runs daily
+and exercises the real dispatch path (this worker image, this agent's auth secret,
+this agent's pinned model, and the structured-result contract) so that a broken
+backend is caught here instead of when a real task is routed to it.
+
+Do exactly this and nothing more:
+
+1. Reply with the single word: OK
+2. Emit your structured result block with `outcome` "success".
+
+Do NOT clone any repository, read files, change files, or push anything. There is
+no work to do beyond confirming you can run and emit a valid result.

--- a/tasks/scheduled/agent-health-gemini.md
+++ b/tasks/scheduled/agent-health-gemini.md
@@ -1,0 +1,26 @@
+---
+profile: small
+agent: gemini
+priority: normal
+status: scheduled
+schedule: "40 13 * * *"
+max_concurrent: 1
+created: "2026-06-28T00:00:00Z"
+---
+
+# Agent health canary — gemini
+
+## Description
+
+This is an automated health check for the `gemini` agent backend. It runs daily
+and exercises the real dispatch path (this worker image, this agent's auth secret,
+this agent's pinned model, and the structured-result contract) so that a broken
+backend is caught here instead of when a real task is routed to it.
+
+Do exactly this and nothing more:
+
+1. Reply with the single word: OK
+2. Emit your structured result block with `outcome` "success".
+
+Do NOT clone any repository, read files, change files, or push anything. There is
+no work to do beyond confirming you can run and emit a valid result.


### PR DESCRIPTION
## Why

Nothing in Claude OS proactively checks that each agent backend (`claude`, `codex`, `gemini`) actually works. A backend can be **silently dead** until a real task is routed to it and fails.

This is the lesson from 2026-06-27/28: `codex` was dead behind **three independent failures** — expired token, an account-restricted default model, and a too-old worker CLI for the pinned model (#22, #23) — and *every one* was found by a human going looking, not by the system.

## What

A daily smoke test per agent that exercises the **real dispatch path** (this worker image, the agent's auth secret, its pinned model, the structured-result contract), so the same class of failure trips a canary *first*:

| Failure mode | Canary catches it |
|---|---|
| Expired token | auth fails → non-zero exit |
| Account-restricted model | `400 not supported` → non-zero exit |
| Too-old CLI for model | `400 requires a newer version` → non-zero exit |
| Broken result contract | no valid result block emitted |

### Pieces
- **`tasks/scheduled/agent-health-{claude,codex,gemini}.md`** — trivial "reply OK" canaries on a staggered daily cron (13:30/13:35/13:40 UTC), via the existing scheduler. No code needed for scheduling.
- **`controller/health`** — on a terminal `agent-health-*` task: open a **deduplicated** GitHub issue on failure, **close it on recovery**. Reuses `comms.Manager` (`Notify` dedups by `TaskID`, `Close` is idempotent) — this package is just the glue + a readable issue body with remediation pointers.
- **`main.go`** — one guard in the existing job-completion handler; a no-op for every non-canary task.

### Coverage note
This is **in-cluster** by design (per scoping with @dacort). It catches per-agent failures; it does **not** catch a total controller/cluster outage (the watcher would be down too). That's an accepted blind spot — a real task surfaces a full outage quickly, and an external heartbeat is a separate later layer.

`gemini` is unconfigured, so its canary is expected to fail with a clear "not configured" issue — making the missing backend **visible and tracked** rather than silently absent. Close it if gemini is intentionally disabled.

## Tests
`controller/health` unit tests cover canary detection, open-on-fail, close-on-recover, non-canary no-op, and the gemini-not-configured body. Full controller suite green; `go build ./...` clean.

## Verify end-to-end (post-merge)
Break codex deliberately (e.g. set a bad `CODEX_MODEL`), confirm one `agent-health` issue opens; restore, confirm the next canary closes it.

Spec: `my-octopus-teacher docs/specs/2026-06-28-agent-health-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)