### PR TITLE
fix(worker): push agent commits instead of dropping them

### DIFF
--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -693,14 +693,32 @@ if [ -d "${WORKDIR}/.git" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
             rmdir "${WORKDIR}/tasks" 2>/dev/null || true
         fi
 
-        # Stage all changes (git add -A) and check if there's anything to commit
+        # Stage whatever the agent left uncommitted.
         git add -A
         if ! git diff --cached --quiet 2>/dev/null; then
             echo "Committing workspace changes..."
             git commit -m "task ${TASK_ID}: ${TASK_TITLE}" \
                 --author="Claude OS <claude-os@noreply.github.com>" 2>&1 || true
+        else
+            echo "Nothing left to stage — the agent may have committed its own work"
+        fi
 
-            # Push with retry (matches controller's retry strategy)
+        # Push on the basis of HEAD vs the remote, NOT on whether staging found
+        # anything. Agents frequently run `git commit` themselves; when they do,
+        # the index is clean here and this block used to skip the push entirely,
+        # so the commit died with the pod while the run still reported success.
+        # When the upstream ref can't be resolved, push anyway — losing an
+        # agent's work is far worse than a redundant push attempt.
+        UPSTREAM_REF="origin/${REPO_REF:-main}"
+        if git rev-parse --verify --quiet "${UPSTREAM_REF}" >/dev/null 2>&1; then
+            AHEAD=$(git rev-list --count "${UPSTREAM_REF}..HEAD" 2>/dev/null || echo 1)
+        else
+            echo "WARNING: cannot resolve ${UPSTREAM_REF}; attempting push regardless"
+            AHEAD=1
+        fi
+
+        if [ "${AHEAD}" -gt 0 ]; then
+            echo "Pushing ${AHEAD} commit(s) ahead of ${UPSTREAM_REF}..."
             for attempt in 1 2 3; do
                 if git push origin HEAD 2>&1; then
                     echo "Pushed workspace changes (attempt ${attempt})"
@@ -714,7 +732,7 @@ if [ -d "${WORKDIR}/.git" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
                 fi
             done
         else
-            echo "No workspace changes to commit"
+            echo "No workspace changes to push — HEAD matches ${UPSTREAM_REF}"
         fi
     else
         echo "Skipping push: autonomy.can_push is false"
@@ -734,6 +752,17 @@ if [ "${WORKDIR}" != "${CLAUDE_OS_DIR}" ] && [ -d "${CLAUDE_OS_DIR}/.git" ] \
         echo "Committing claude-os bookkeeping (state files / follow-up tasks)..."
         git -C "${CLAUDE_OS_DIR}" commit -m "task ${TASK_ID}: bookkeeping (state/follow-up tasks)" \
             --author="Claude OS <claude-os@noreply.github.com>" 2>&1 || true
+    fi
+
+    # Same rule as the workspace push above: an agent that committed in the
+    # claude-os clone would otherwise leave those commits stranded in the pod.
+    if git -C "${CLAUDE_OS_DIR}" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+        BK_AHEAD=$(git -C "${CLAUDE_OS_DIR}" rev-list --count origin/main..HEAD 2>/dev/null || echo 1)
+    else
+        BK_AHEAD=1
+    fi
+
+    if [ "${BK_AHEAD}" -gt 0 ]; then
         for attempt in 1 2 3; do
             if git -C "${CLAUDE_OS_DIR}" push origin HEAD 2>&1; then
                 echo "Pushed claude-os bookkeeping (attempt ${attempt})"

--- a/worker/test-push-logic.sh
+++ b/worker/test-push-logic.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Exercises the fixed push logic from worker/entrypoint.sh against the three
+# ways an agent can leave a workspace. Case B is the regression: it is what
+# lost the favicon work.
+set -u
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "${SANDBOX}"' EXIT
+PASS=0; FAIL=0
+
+# The block under test, lifted from worker/entrypoint.sh.
+run_push_block() {
+    local WORKDIR="$1" REPO_REF="main" TASK_ID="t1" TASK_TITLE="test task"
+    cd "${WORKDIR}" || return 1
+    PUSH_EXIT=0
+
+    git add -A
+    if ! git diff --cached --quiet 2>/dev/null; then
+        echo "Committing workspace changes..."
+        git commit -m "task ${TASK_ID}: ${TASK_TITLE}" \
+            --author="Claude OS <claude-os@noreply.github.com>" >/dev/null 2>&1 || true
+    else
+        echo "Nothing left to stage — the agent may have committed its own work"
+    fi
+
+    UPSTREAM_REF="origin/${REPO_REF:-main}"
+    if git rev-parse --verify --quiet "${UPSTREAM_REF}" >/dev/null 2>&1; then
+        AHEAD=$(git rev-list --count "${UPSTREAM_REF}..HEAD" 2>/dev/null || echo 1)
+    else
+        echo "WARNING: cannot resolve ${UPSTREAM_REF}; attempting push regardless"
+        AHEAD=1
+    fi
+
+    if [ "${AHEAD}" -gt 0 ]; then
+        echo "Pushing ${AHEAD} commit(s) ahead of ${UPSTREAM_REF}..."
+        git push origin HEAD >/dev/null 2>&1 && echo "Pushed workspace changes"
+    else
+        echo "No workspace changes to push — HEAD matches ${UPSTREAM_REF}"
+    fi
+}
+
+new_repo() {
+    local name="$1"
+    git init -q --bare "${SANDBOX}/${name}.git"
+    git clone -q "${SANDBOX}/${name}.git" "${SANDBOX}/${name}"
+    cd "${SANDBOX}/${name}"
+    git config user.email t@t; git config user.name t
+    echo seed > seed.txt; git add -A
+    git commit -qm seed; git push -q origin HEAD:main 2>/dev/null
+    git branch -q -M main 2>/dev/null || true
+    git fetch -q origin 2>/dev/null
+}
+
+check() {
+    local label="$1" repo="$2" want="$3"
+    local got
+    got=$(git --git-dir="${SANDBOX}/${repo}.git" log --oneline 2>/dev/null | grep -c "$want")
+    if [ "${got}" -ge 1 ]; then
+        echo "  PASS: ${label}"; PASS=$((PASS+1))
+    else
+        echo "  FAIL: ${label} — '${want}' never reached the remote"; FAIL=$((FAIL+1))
+    fi
+}
+
+echo "=== Case A: agent leaves changes UNCOMMITTED (worked before too) ==="
+new_repo caseA
+echo "favicon" > favicon.svg
+run_push_block "${SANDBOX}/caseA" | sed 's/^/  /'
+check "uncommitted work reaches remote" caseA "test task"
+
+echo
+echo "=== Case B: agent COMMITS its own work (the regression) ==="
+new_repo caseB
+echo "favicon" > favicon.svg
+git add -A && git commit -qm "feat: add favicon (agent's own commit)"
+run_push_block "${SANDBOX}/caseB" | sed 's/^/  /'
+check "agent's own commit reaches remote" caseB "agent's own commit"
+
+echo
+echo "=== Case C: agent changes NOTHING (must stay quiet, push nothing) ==="
+new_repo caseC
+out=$(run_push_block "${SANDBOX}/caseC")
+echo "${out}" | sed 's/^/  /'
+if echo "${out}" | grep -q "No workspace changes to push"; then
+    echo "  PASS: correctly reports nothing to push"; PASS=$((PASS+1))
+else
+    echo "  FAIL: did not report an empty run"; FAIL=$((FAIL+1))
+fi
+
+echo
+echo "=== ${PASS} passed, ${FAIL} failed ==="
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
A worker task can report `outcome: success` while silently discarding everything the agent built.

## What happened

A favicon task dispatched through Forge to `dacort/forge` came back green — Forge marked the card **shipped** — and nothing reached the repo. Reconstructed from the worker log:

1. The agent wrote `web/static/favicon.svg` and edited both `index.html` files. **Real work.**
2. The agent ran `git commit` itself → `d68fbbd`. **A real commit, in the pod's clone.**
3. The worker ran `git add -A` → nothing to stage, because it was already committed.
4. `git diff --cached --quiet` succeeded → `else` branch → logged `No workspace changes to commit`.
5. **The push never ran.** It is unreachable from that branch.
6. Pod died. Commit died with it. `d68fbbd` exists nowhere.

`Push exit: 0` throughout, because `PUSH_EXIT` only gets set by a push that *fails* — one that never runs can't.

## Cause

The push loop was nested inside the "is anything staged?" check:

```sh
git add -A
if ! git diff --cached --quiet; then
    git commit ...
    for attempt in 1 2 3; do git push ... done   # only reachable here
else
    echo "No workspace changes to commit"        # push skipped entirely
fi
```

Agents frequently commit their own work — so **the more thorough the agent, the more certain its work is lost.** This also explains why it's intermittent rather than total: earlier tasks landed only because those agents happened to leave their changes unstaged.

## Fix

Push keys off `HEAD` vs the remote instead of off the index, so it covers both shapes. If the upstream ref can't be resolved it pushes anyway — a redundant push attempt is far cheaper than losing an agent's work. The claude-os bookkeeping block below had the identical nesting and gets the same treatment.

The log line was misleading in its own right: "No workspace changes to commit" meant *nothing uncommitted*, not *the agent did nothing*. It now distinguishes the two, which matters because that line is what made this look like an agent failure rather than a worker bug.

## Verification

`worker/test-push-logic.sh` covers the three shapes a workspace can end in:

```
=== Case A: agent leaves changes UNCOMMITTED ===   PASS
=== Case B: agent COMMITS its own work ===         PASS   <- the regression
=== Case C: agent changes NOTHING ===              PASS
```

Case B is the one that matters, and it genuinely catches the bug — run against the old logic, the agent's commit never reaches the remote and it prints `No workspace changes to commit`, reproducing the incident exactly.

There's no shell test runner in the repo yet, so it's standalone: `bash worker/test-push-logic.sh`. Happy to drop it if you'd rather not introduce the pattern.

## Related

- **#30** (stream agent activity to logs) — `claude -p --output-format text` buffers everything, so the log shows no tool calls whether or not tools ran. That's what made this look like the agent had fabricated its summary.
- **#31** (expose commit SHA / files on the result) — with this fix the work gets pushed, but Forge still can't distinguish a real ship from a no-op run without a structural signal.

Worth a separate look: this task was dispatched as `profile: medium` (`default_model: claude-sonnet-4-6`) and ran on `claude-haiku-4-5`. No keyword in `heuristic.go` matches the task text, so the override came from LLM triage. Not related to this bug — the work was done correctly and then thrown away — but the routing is surprising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)